### PR TITLE
fix neptune breaking on latest Tidal version (2.37.8)

### DIFF
--- a/injector/index.js
+++ b/injector/index.js
@@ -187,6 +187,7 @@ const ProxiedBrowserWindow = new Proxy(electron.BrowserWindow, {
       // Shhh. I can feel your judgement from here. It's okay. Let it out. Everything will be alright in the end.
       options.webPreferences.contextIsolation = false;
       options.webPreferences.nodeIntegration = true;
+      options.webPreferences.sandbox = false;
 
       // Allows local plugin loading
       options.webPreferences.allowDisplayingInsecureContent = true;


### PR DESCRIPTION
On the latest of version of Tidal sandboxing has been enabled which totally breaks the preload script stuff like this
`const electronPath = require.resolve("electron");`
Won't work if sandbox is enabled
This pr just disable sandboxing