### PR TITLE
Theme improvements

### DIFF
--- a/injector/index.js
+++ b/injector/index.js
@@ -95,6 +95,18 @@ electron.app.whenReady().then(() => {
 });
 // #endregion
 
+// #region Stylesheet bypass
+electron.app.whenReady().then(() => {
+	session.defaultSession.webRequest.onHeadersReceived(({ responseHeaders, resourceType }, cb) => {
+		if (responseHeaders && resourceType === "stylesheet") {
+			const header = Object.keys(responseHeaders).find(h => h.toLowerCase() === "content-type") || "content-type";
+			responseHeaders[header] = "text/css";
+		}
+		cb({ cancel: false, responseHeaders });
+	});
+});
+// #endregion
+
 // #region IPC Bullshit
 let evalHandleCount = 0;
 let evalHandles = {};

--- a/src/api/themes.js
+++ b/src/api/themes.js
@@ -26,22 +26,28 @@ export function toggleTheme(url) {
 
 export async function importTheme(url, enabled = true) {
   let manifest;
+  let text;
 
   try {
-    manifest = parseManifest(await (await fetch(url)).text());
+	text = await (await fetch(url)).text();
   } catch {
-    throw "Failed to parse theme manifest!";
+	throw "Failed to fetch theme!";
   }
 
-  if (!["name", "author", "description"].every((i) => typeof manifest[i] === "string"))
-    throw "Manifest doesn't contain required properties!";
-
-  const { name, author, description } = manifest;
+  try {
+    manifest = parseManifest(text);
+  } catch (e) {
+    manifest = {
+		name: url.split("/").pop(),
+		author: "Unknown",
+		description: "No description provided.",
+	}
+  }
 
   themesStore.unshift({
-    name,
-    author,
-    description,
+    name: manifest.name,
+    author: manifest.author,
+    description: manifest.description,
     enabled,
     url,
   });


### PR DESCRIPTION
* Bypass `Content-Type` header for stylesheets, so that themes can be imported from anywhere (e.g. GitHub).
* Fallback to using the file name as a theme name if there isn't a manifest, rather than requiring it.