### PR TITLE
Change native code execution to use async `ipcRenderer.invoke`

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,5 @@
 {
-  "printWidth": 100,
+  "printWidth": 160,
   "tabWidth": 2,
   "useTabs": false,
   "semi": true,


### PR DESCRIPTION
As stated this changes the invoke calls to use async and will require build scripts to be changed to use:

```ts
return {
	contents: `
	import { addUnloadable } from "@plugin";
	const scopeId = await NeptuneNative.createEvalScope(${JSON.stringify(outputCode)}, "${globalName}");
	${builtExports.reduce((exports, exp) => (exports += `export ${exp == "default" ? "default " : `const ${exp} =`} (...args) => NeptuneNative.invokeEvalScope(scopeId, "${exp}", ...args);`), "")}
	addUnloadable(() => NeptuneNative.deleteEvalScope(scopeId))`,
};
```

I looked into identifying the calling function constructor to determine if the response was async or not. But there is no safe way to determine this as a synchronous function can return a promise. 

Since all calls to the native side should be async anyway re the official electron docs and general best practises:
![image](https://github.com/user-attachments/assets/bccc502e-0ea2-4964-9144-a9b9c3992837)

As this results in exported native methods needing to return promises docs should reflect the need to use async methods.

Switching to invoke fixes issues with serialization and performance especially on initial load.