### PR TITLE
Adding an overlay into NixOS via flakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,37 @@ neptune is an experimental client mod for TIDAL that provides a simple plugin an
 ## how can i install neptune?
 you can download the neptune installer [here](https://github.com/uwu/neptune-installer/releases).
 
+### NixOS
+
+> [!WARNING]
+> TIDAL-HIFI right now is colliding with neptune when trying to login
+>
+> create a nix-shell with tidal-hifi and login once, after that you can use the neptune package
+
+you install this package as an overlay
+
+add as an input in your flakes:
+´´´nix 
+  inputs = {
+    neptune = {
+      url = "github.com:uwu/neptune";
+      inputs.nixpkgs.follows = "nixpkgs";
+    }
+  };
+´´´
+
+configure your package system to use this overlay:
+```nix
+nixpkgs.overlays = [ inputs.neptune.overlays.default ];
+```
+
+and then just add neptune as a package:
+```nix
+enivronment.systemPackages = [ pkgs.neptune ];
+```
+
+After that you can find TIDAL-HIFI as program in your system
+
 ## developing plugins for neptune
 neptune exfiltrates every single action one can do in TIDAL into an easily accessible API found on `window.neptune.actions`.
 

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1733376361,
+        "narHash": "sha256-aLJxoTDDSqB+/3orsulE6/qdlX6MzDLIITLZqdgMpqo=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "929116e316068c7318c54eb4d827f7d9756d5e9c",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -6,75 +6,35 @@
   outputs = inputs:
     let
       neptuneOverlay = final: prev: 
+        let
+          neptune-src = prev.fetchzip {
+            url = "https://github.com/uwu/neptune/archive/refs/heads/master.zip";
+            sha256 = "sha256-6aFIQyZwlqaiyVpZa9CVj3Hf94BJRSAKHEQl5QH/Xvw=";
+          };
+        in
+        {
+          # Use the already existing package tidal-hifi and inject neptune in it
+          tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
+            # Patch neptune into tidal-hifi
+            installPhase = old.installPhase or "" + ''
+              cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
+              mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
+              
+            '';
+          });
 
-      let
-        neptune-src = prev.fetchzip {
-          url = "https://github.com/uwu/neptune/archive/refs/heads/master.zip";
-          sha256 = "sha256-6aFIQyZwlqaiyVpZa9CVj3Hf94BJRSAKHEQl5QH/Xvw=";
+          # declare a new package named neptune that uses the new tidal-hifi
+          neptune = final.tidal-hifi;
         };
-      in
-
-      {
-        # Use the already existing package tidal-hifi and inject neptune in it
-        tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
-          # Patch neptune into tidal-hifi
-          installPhase = old.installPhase or "" + ''
-            cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
-            mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
-            
-          '';
-        });
-
-        # declare a new package named neptune that uses the new tidal-hifi
-        neptune = final.tidal-hifi;
-      };
-
+      
       system = "x86_64-linux"; # This setting is based on my system, change if needed
 
       # The Module Configuration
-      module = 
-      { isNixOsModule ? false, ... }:
-      { config, lib, pkgs, ... }:
-      with lib;
-      let
-        cfg = config.programs.neptune;
-      in {
-        options.programs.neptune = {
-          enable = mkEnableOption "Wheter or not to enable the experimental TIDAL client neptune";
-          package = mkOption {
-            type = types.package;
-            default = pkgs.neptune;
-            example = pkgs.tidal-hifi; # Wont be able to use plugins/themes
-          };
-
-          plugins = mkOption {
-            type = (types.listOf types.strMatching "(https?://(?:www.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|https?://(?:www.|(?!www))[a-zA-Z0-9]+.[^\s]{2,}|www.[a-zA-Z0-9]+.[^\s]{2,})"); # Only Accept URLs
-            default = [];
-            example = [
-              "https://inrixia.github.io/neptune-plugins/DiscordRPC" # Discord RPC
-              "https://inrixia.github.io/neptune-plugins/TidalTags" # Tag System for bitrate
-            ];
-          };
-
-          themes = mkOption {
-            type = (types.listOf types.strMatching "(https?://(?:www.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|https?://(?:www.|(?!www))[a-zA-Z0-9]+.[^\s]{2,}|www.[a-zA-Z0-9]+.[^\s]{2,})"); # Only Accept URLs
-            default = [];
-            example = [
-              "https://raw.githubusercontent.com/Inrixia/neptune-plugins/refs/heads/master/themes/blur.css" # Blur Theme
-            ];
-          };
-        };
-
-        config = mkIf cfg.enable {
-          # Install package if it is a NixOsModule for NixOS or if it is a home-manager module, for home-manager
-          environment.systemPackages = if isNixOsModule then [ cfg.package ] else []; 
-          home.packages = if isNixOsModule then [ ] else [ cfg.package ]; 
-
-
-        };
-      };
+      # Disclaimer: There is no module configuration yet, because I dont have a solution myself, to get access to the InnoDB
 
     in {
+      # Overlay used by other flakes
+      overlays.default = neptuneOverlay;
 
       # Testing the overlay/package
       devShells."${system}".default = let

--- a/flake.nix
+++ b/flake.nix
@@ -6,32 +6,77 @@
   outputs = inputs:
     let
       neptuneOverlay = final: prev: 
-        let
-          neptune-src = prev.fetchzip {
-            url = "https://github.com/uwu/neptune/archive/refs/heads/master.zip";
-            sha256 = "sha256-6aFIQyZwlqaiyVpZa9CVj3Hf94BJRSAKHEQl5QH/Xvw=";
+
+      let
+        neptune-src = prev.fetchzip {
+          url = "https://github.com/uwu/neptune/archive/refs/heads/master.zip";
+          sha256 = "sha256-6aFIQyZwlqaiyVpZa9CVj3Hf94BJRSAKHEQl5QH/Xvw=";
+        };
+      in
+
+      {
+        # Use the already existing package tidal-hifi and inject neptune in it
+        tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
+          # Patch neptune into tidal-hifi
+          installPhase = old.installPhase or "" + ''
+            cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
+            mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
+            
+          '';
+        });
+
+        # declare a new package named neptune that uses the new tidal-hifi
+        neptune = final.tidal-hifi;
+      };
+
+      system = "x86_64-linux"; # This setting is based on my system, change if needed
+
+      # The Module Configuration
+      module = 
+      { isNixOsModule ? false, ... }:
+      { config, lib, pkgs, ... }:
+      with lib;
+      let
+        cfg = config.programs.neptune;
+      in {
+        options.programs.neptune = {
+          enable = mkEnableOption "Wheter or not to enable the experimental TIDAL client neptune";
+          package = mkOption {
+            type = types.package;
+            default = pkgs.neptune;
+            example = pkgs.tidal-hifi; # Wont be able to use plugins/themes
           };
-        in
 
-        {
-          # Use the already existing package tidal-hifi and inject neptune in it
-          tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
-            # Patch neptune into tidal-hifi
-            installPhase = old.installPhase or "" + ''
-              cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
-              mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
-              
-            '';
-          });
+          plugins = mkOption {
+            type = (types.listOf types.strMatching "(https?://(?:www.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|https?://(?:www.|(?!www))[a-zA-Z0-9]+.[^\s]{2,}|www.[a-zA-Z0-9]+.[^\s]{2,})"); # Only Accept URLs
+            default = [];
+            example = [
+              "https://inrixia.github.io/neptune-plugins/DiscordRPC" # Discord RPC
+              "https://inrixia.github.io/neptune-plugins/TidalTags" # Tag System for bitrate
+            ];
+          };
 
-          # declare a new package named neptune that uses the new tidal-hifi
-          neptune = final.tidal-hifi;
+          themes = mkOption {
+            type = (types.listOf types.strMatching "(https?://(?:www.|(?!www))[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|www.[a-zA-Z0-9][a-zA-Z0-9-]+[a-zA-Z0-9].[^\s]{2,}|https?://(?:www.|(?!www))[a-zA-Z0-9]+.[^\s]{2,}|www.[a-zA-Z0-9]+.[^\s]{2,})"); # Only Accept URLs
+            default = [];
+            example = [
+              "https://raw.githubusercontent.com/Inrixia/neptune-plugins/refs/heads/master/themes/blur.css" # Blur Theme
+            ];
+          };
         };
 
-    system = "x86_64-linux"; # This setting is based on my system, change if needed
+        config = mkIf cfg.enable {
+          # Install package if it is a NixOsModule for NixOS or if it is a home-manager module, for home-manager
+          environment.systemPackages = if isNixOsModule then [ cfg.package ] else []; 
+          home.packages = if isNixOsModule then [ ] else [ cfg.package ]; 
 
+
+        };
+      };
 
     in {
+
+      # Testing the overlay/package
       devShells."${system}".default = let
         pkgs = import inputs.nixpkgs { 
           inherit system; 
@@ -39,11 +84,7 @@
         };
         in pkgs.mkShell {
           packages = [ pkgs.neptune ];
-          shellHook = ''
-            echo "Neptune Overlay installed!"
-            ${pkgs.neptune}/bin/tidal-hifi
-            echo "Neptune Started!"
-          '';
+          shellHook = '' ${pkgs.neptune}/bin/tidal-hifi ''; # Activating the package/overlay
         };
     };
 }

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,49 @@
+{
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
+  };
+
+  outputs = inputs:
+    let
+      neptuneOverlay = final: prev: 
+        let
+          neptune-src = prev.fetchzip {
+            url = "https://github.com/uwu/neptune/archive/refs/heads/master.zip";
+            sha256 = "sha256-6aFIQyZwlqaiyVpZa9CVj3Hf94BJRSAKHEQl5QH/Xvw=";
+          };
+        in
+
+        {
+          # Use the already existing package tidal-hifi and inject neptune in it
+          tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
+            # Patch neptune into tidal-hifi
+            installPhase = old.installPhase or "" + ''
+              cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
+              mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
+              
+            '';
+          });
+
+          # declare a new package named neptune that uses the new tidal-hifi
+          neptune = final.tidal-hifi;
+        };
+
+    system = "x86_64-linux"; # This setting is based on my system, change if needed
+
+
+    in {
+      devShells."${system}".default = let
+        pkgs = import inputs.nixpkgs { 
+          inherit system; 
+          overlays = [ neptuneOverlay ];
+        };
+        in pkgs.mkShell {
+          packages = [ pkgs.neptune ];
+          shellHook = ''
+            echo "Neptune Overlay installed!"
+            ${pkgs.neptune}/bin/tidal-hifi
+            echo "Neptune Started!"
+          '';
+        };
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -15,11 +15,22 @@
         {
           # Use the already existing package tidal-hifi and inject neptune in it
           tidal-hifi = prev.tidal-hifi.overrideAttrs (old: {
+            
             # Patch neptune into tidal-hifi
-            installPhase = old.installPhase or "" + ''
+            # Needing to override the full thing to get everything from the install phase
+            installPhase = ''
+              runHook preInstall
+
+              mkdir -p "$out/bin"
+              cp -R "opt" "$out"
+              cp -R "usr/share" "$out/share"
+              chmod -R g-w "$out"
+
               cp -r ${neptune-src}/injector/ $out/opt/tidal-hifi/resources/app/
               mv $out/opt/tidal-hifi/resources/app.asar $out/opt/tidal-hifi/resources/original.asar
               
+              runHook postInstall
+
             '';
           });
 


### PR DESCRIPTION
Fixes Issue: #40

There is still a small bug where you cant login when the client is injected.
I think that is because neptune and the tidal-hifi package itself is somehow colliding.

A small workarround for that is to install the tidal-hifi package in a shell and login there, after that the cookie is saved and you can use the neptune client

---

As I already mentionend in the issue, as long as the plugins/themes are storred in a DB, I can not create a module until I found some workarround